### PR TITLE
Adds canary support

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ include chrome
 
 # from the dev channel
 include chome::dev
+
+# from the nightly channel
+include chome::canary
 ```
 
 ## Required Puppet Modules

--- a/manifests/canary.pp
+++ b/manifests/canary.pp
@@ -1,0 +1,10 @@
+# Public: Install Chrome developer channel build to /Applications.
+#
+# Examples
+#
+#   include chrome::dev
+class chrome::canary inherits chrome {
+  Package['Chrome'] {
+    source => 'https://storage.googleapis.com/chrome-canary/GoogleChromeCanary.dmg',
+  }
+}


### PR DESCRIPTION
Canary is the nightly that runs alongside other Chrome channels allowing for easier development without fear of wiping out cookies and other storage from your regular browser. Plus, it gets all the dev tools quicker.
