### PR TITLE
Fix chromium install with custom provider

### DIFF
--- a/lib/puppet/provider/package/chromium.rb
+++ b/lib/puppet/provider/package/chromium.rb
@@ -1,0 +1,54 @@
+require "open-uri"
+require "puppet/provider/package"
+
+Puppet::Type.type(:package).provide :chromium,
+:parent => Puppet::Provider::Package do
+  desc "Installs Chromium"
+
+  APP_PATH = '/Applications/Chromium.app'
+  UNZIP_PATH = '/opt/boxen/cache/Chromium'
+  CACHED_PATH = "#{UNZIP_PATH}.zip"
+  UNZIP_APP_PATH = "#{UNZIP_PATH}/chrome-mac"
+
+  confine  :operatingsystem => :darwin
+
+  commands :curl  => "/usr/bin/curl"
+  commands :ditto => "/usr/bin/ditto"
+  commands :chown => "/usr/sbin/chown"
+  commands :rm    => "/bin/rm"
+
+  def self.instances_by_name
+    return [] unless File.exists? APP_PATH
+    yield 'Chromium' if block_given?
+    ['Chromium']
+  end
+
+  def self.instances
+    instances_by_name.collect do |name|
+      new(:name => name, :provider => :chromium, :ensure => :installed)
+    end
+  end
+
+  def query
+    return nil unless File.exists? APP_PATH
+    { :name => @resource[:name], :ensure => :installed }
+  end
+
+  def install
+    fail("Chromium can only install Chromium") unless @resource[:name] == 'Chromium'
+    fail("OS X compressed apps must specify a package name") unless @resource[:name]
+    fail("OS X compressed apps must specify a package source") unless @resource[:source]
+
+    FileUtils.mkdir_p '/opt/boxen/cache'
+    curl @resource[:source], "-Lqo", CACHED_PATH
+    rm "-rf", APP_PATH
+    rm "-rf", UNZIP_PATH
+    ditto "-xk", CACHED_PATH, UNZIP_PATH
+    ditto UNZIP_APP_PATH, "/Applications"
+    chown "-R", "#{Facter[:boxen_user].value}:staff", APP_PATH
+  end
+
+  def uninstall
+    rm "-rf", APP_PATH
+  end
+end

--- a/manifests/chromium.pp
+++ b/manifests/chromium.pp
@@ -6,9 +6,9 @@
 class chrome::chromium (
   $version = latest_chromium(),
 ) {
-  # compressed_app package provider is a custom puppet-boxen provider
+  # chromium package provider is a custom provider
   package { 'Chromium':
-    provider => 'compressed_app',
+    provider => 'chromium',
     source   => "http://commondatastorage.googleapis.com/chromium-browser-continuous/Mac/${version}/chrome-mac.zip",
   }
 }

--- a/spec/classes/chrome_chromium_spec.rb
+++ b/spec/classes/chrome_chromium_spec.rb
@@ -6,7 +6,7 @@ describe 'chrome::chromium' do
   end
   it do
     should contain_package('Chromium').with({
-      :provider => 'compressed_app',
+      :provider => 'chromium',
       :source   => 'http://commondatastorage.googleapis.com/chromium-browser-continuous/Mac/LATEST/chrome-mac.zip',
     })
   end


### PR DESCRIPTION
The `compressed_app` package provider expects the app bundle to live in the top-level folder. The Chromium zip has a `chrome-mac` subfolder, which breaks the `compressed_app` provider. I added a tiny custom package provider to handle Chromium specifically.
