### PR TITLE
Add extension support

### DIFF
--- a/manifests/canary/extension.pp
+++ b/manifests/canary/extension.pp
@@ -1,0 +1,18 @@
+# Public: Install Chrome Canary extension
+#
+# Examples
+#
+#   chrome::canary::extension { 'Reddit Enhancement Suite':
+#     id => 'kbmfpngjjgdllneeigpgjifpgocmfgmb',
+#   }
+define chrome::canary::extension(
+  $id,
+  $source = undef,
+  $path = "/Users/${::boxen_user}/Library/Application Support/Google/Chrome Canary/External Extensions",
+) {
+  chrome::extension { "${title}-canary":
+    id      => $id,
+    source  => $source,
+    path    => $path,
+  }
+}

--- a/manifests/chromium/extension.pp
+++ b/manifests/chromium/extension.pp
@@ -1,0 +1,18 @@
+# Public: Install Chromium extension
+#
+# Examples
+#
+#   chrome::chromium::extension { 'Reddit Enhancement Suite':
+#     id => 'kbmfpngjjgdllneeigpgjifpgocmfgmb',
+#   }
+define chrome::chromium::extension(
+  $id,
+  $source = undef,
+  $path = "/Users/${::boxen_user}/Library/Application Support/Chromium/External Extensions",
+) {
+  chrome::extension { "${title}-chromium":
+    id      => $id,
+    source  => $source,
+    path    => $path,
+  }
+}

--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -1,0 +1,24 @@
+# Public: Install Chrome extension
+#
+# Examples
+#
+#   chrome::extension { 'Reddit Enhancement Suite':
+#     id => 'kbmfpngjjgdllneeigpgjifpgocmfgmb',
+#   }
+define chrome::extension(
+  $id,
+  $source = 'https://clients2.google.com/service/update2/crx',
+  $path = "/Users/${::boxen_user}/Library/Application Support/Google/Chrome/External Extensions",
+) {
+  exec { "chrome-ext-dir-${title}":
+    command => "/bin/mkdir -p '${path}'",
+    creates => $path,
+  }
+  ->
+  file { "chrome-ext-${title}":
+    ensure  => present,
+    path    => "${path}/${id}.json",
+    mode    => '0644',
+    content => "{\"external_update_url\": \"${source}\"}",
+  }
+}

--- a/spec/defines/chrome_canary_extension_spec.rb
+++ b/spec/defines/chrome_canary_extension_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe 'chrome::canary::extension' do
+  let(:facts) {
+    { :boxen_user => 'boxen' }
+  }
+
+  let(:title)   { 'Some Extension' }
+  let(:id)      { 'gdllpgocmfneeigkbmfpngjjpgjifgmb' }
+  let(:path)    { '/Users/boxen/Library/Application Support/Google/Chrome Canary/External Extensions' }
+  let(:source)  { 'https://clients2.google.com/service/update2/crx' }
+
+  let(:params) {
+    { :id => id }
+  }
+
+  it do
+    should contain_chrome__extension("#{title}-canary").with({
+      :id   => id,
+      :path => path,
+    })
+  end
+
+  context 'with source' do
+    let(:source) { 'https://example.com/ext.xml' }
+
+    let(:params) {
+      { :id     => id,
+        :source => source,
+      }
+    }
+
+    it do
+      should contain_chrome__extension("#{title}-canary").with({
+        :id     => id,
+        :path   => path,
+        :source => source,
+      })
+    end
+  end
+
+  context 'with path' do
+    let(:path) { '/some/path' }
+
+    let(:params) {
+      { :id   => id,
+        :path => path,
+      }
+    }
+
+    it do
+      should contain_chrome__extension("#{title}-canary").with({
+        :id   => id,
+        :path => path,
+      })
+    end
+  end
+end

--- a/spec/defines/chrome_chromium_extension_spec.rb
+++ b/spec/defines/chrome_chromium_extension_spec.rb
@@ -1,0 +1,58 @@
+require 'spec_helper'
+
+describe 'chrome::chromium::extension' do
+  let(:facts) {
+    { :boxen_user => 'boxen' }
+  }
+
+  let(:title)   { 'Some Extension' }
+  let(:id)      { 'gdllpgocmfneeigkbmfpngjjpgjifgmb' }
+  let(:path)    { '/Users/boxen/Library/Application Support/Chromium/External Extensions' }
+  let(:source)  { 'https://clients2.google.com/service/update2/crx' }
+
+  let(:params) {
+    { :id => id }
+  }
+
+  it do
+    should contain_chrome__extension("#{title}-chromium").with({
+      :id   => id,
+      :path => path,
+    })
+  end
+
+  context 'with source' do
+    let(:source) { 'https://example.com/ext.xml' }
+
+    let(:params) {
+      { :id     => id,
+        :source => source,
+      }
+    }
+
+    it do
+      should contain_chrome__extension("#{title}-chromium").with({
+        :id     => id,
+        :path   => path,
+        :source => source,
+      })
+    end
+  end
+
+  context 'with path' do
+    let(:path) { '/some/path' }
+
+    let(:params) {
+      { :id   => id,
+        :path => path,
+      }
+    }
+
+    it do
+      should contain_chrome__extension("#{title}-chromium").with({
+        :id   => id,
+        :path => path,
+      })
+    end
+  end
+end

--- a/spec/defines/chrome_extension_spec.rb
+++ b/spec/defines/chrome_extension_spec.rb
@@ -1,0 +1,68 @@
+require 'spec_helper'
+
+describe 'chrome::extension' do
+  let(:facts) {
+    { :boxen_user => 'boxen' }
+  }
+
+  let(:title)   { 'Some Extension' }
+  let(:id)      { 'gdllpgocmfneeigkbmfpngjjpgjifgmb' }
+  let(:path)    { '/Users/boxen/Library/Application Support/Google/Chrome/External Extensions' }
+  let(:source)  { 'https://clients2.google.com/service/update2/crx' }
+
+  let(:params) {
+    { :id => id }
+  }
+
+  it do
+    should contain_exec("chrome-ext-dir-#{title}").with({
+      :command => "/bin/mkdir -p '#{path}'",
+      :creates => path,
+    })
+
+    should contain_file("chrome-ext-#{title}").with({
+      :ensure   => 'present',
+      :path     => "#{path}/#{id}.json",
+      :mode     => '0644',
+      :content  => "{\"external_update_url\": \"#{source}\"}",
+    })
+  end
+
+  context 'with source' do
+    let(:source) { 'https://example.com/ext.xml' }
+
+    let(:params) {
+      { :id     => id,
+        :source => source,
+      }
+    }
+
+    it do
+      should contain_file("chrome-ext-#{title}").with({
+        :ensure   => 'present',
+        :path     => "#{path}/#{id}.json",
+        :mode     => '0644',
+        :content  => "{\"external_update_url\": \"#{source}\"}",
+      })
+    end
+  end
+
+  context 'with path' do
+    let(:path) { '/some/path' }
+
+    let(:params) {
+      { :id   => id,
+        :path => path,
+      }
+    }
+
+    it do
+      should contain_file("chrome-ext-#{title}").with({
+        :ensure   => 'present',
+        :path     => "#{path}/#{id}.json",
+        :mode     => '0644',
+        :content  => "{\"external_update_url\": \"#{source}\"}",
+      })
+    end
+  end
+end


### PR DESCRIPTION
Let's you do

```
chrome::extension { 'Reddit Enhancement Suite':
  id => 'kbmfpngjjgdllneeigpgjifpgocmfgmb',
}

chrome::canary::extension { 'Reddit Enhancement Suite':
  id => 'kbmfpngjjgdllneeigpgjifpgocmfgmb',
}

chrome::chromium::extension { 'Reddit Enhancement Suite':
  id => 'kbmfpngjjgdllneeigpgjifpgocmfgmb',
}
```

Since beta, dev and stable Chrome share the same profile there isn't a point in having `chrome::dev::extension`, etc.
